### PR TITLE
Move docs generation out of the exported packages

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,11 +30,11 @@ sh_test(
     name = "stardoc_up_to_date",
     srcs = ["//tools:diff.sh"],
     args = [
-        "$(location //tools:docs.md)",
+        "$(location //docs:docs.md)",
         "$(location README_DOCS.md)",
     ],
     data = [
         "README_DOCS.md",
-        "//tools:docs.md",
+        "//docs:docs.md",
     ],
 )

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+
+stardoc(
+    name = "docs",
+    out = "docs.md",
+    input = "//tools:codeowners.bzl",
+    visibility = ["//:__pkg__"],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,10 +1,1 @@
-exports_files(["diff.sh"])
-
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
-
-stardoc(
-    name = "docs",
-    out = "docs.md",
-    input = "codeowners.bzl",
-    visibility = ["//:__pkg__"],
-)
+exports_files(["diff.sh", "codeowners.bzl"])


### PR DESCRIPTION
This removes the dependency on stardoc for downstream users.

This fixes #21 